### PR TITLE
refactor(requests_go):修复现在 tls.peet.ws 网站字段缺失导致报错的问题

### DIFF
--- a/requests_go/tls_config/convert_config.py
+++ b/requests_go/tls_config/convert_config.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from .config import TLSConfig
 
 # X.509证书数字签名算法英文形式标识符
@@ -55,11 +57,24 @@ def to_tls_config(config: dict) -> TLSConfig:
     return tls_config
 
 
+def fix_exception(func):
+    @wraps(func)
+    def inner(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except:  # noqa
+            return None
+
+    return inner
+
+
+@fix_exception
 def get_ja3_string(config):
     ja3_string = config["tls"]["ja3"]
     return ja3_string
 
 
+@fix_exception
 def get_header_order(config):
     headers = {}
     headers_list = []
@@ -78,6 +93,7 @@ def get_header_order(config):
     return list(headers.keys())
 
 
+@fix_exception
 def get_force_http1(config):
     force_http1 = False
     if config["http_version"] != "h2":
@@ -85,6 +101,7 @@ def get_force_http1(config):
     return force_http1
 
 
+@fix_exception
 def get_pseudo_header_order(config):
     headers = {}
     headers_list = []
@@ -102,6 +119,7 @@ def get_pseudo_header_order(config):
     return list(headers.keys())
 
 
+@fix_exception
 def get_supported_signature_algorithms(config):
     supported_signature_algorithms = []
     extensions = config["tls"]["extensions"]
@@ -115,6 +133,7 @@ def get_supported_signature_algorithms(config):
     return None
 
 
+@fix_exception
 def get_cert_compression_algo(config):
     cert_compression_algo = None
     extensions = config["tls"]["extensions"]
@@ -127,6 +146,7 @@ def get_cert_compression_algo(config):
     return cert_compression_algo
 
 
+@fix_exception
 def get_record_size_limit(config):
     record_size_limit = None
     extensions = config["tls"]["extensions"]
@@ -136,6 +156,7 @@ def get_record_size_limit(config):
     return record_size_limit
 
 
+@fix_exception
 def get_supported_delegated_credentials_algorithms(config):
     supported_delegated_credentials_algorithms = []
     extensions = config["tls"]["extensions"]
@@ -149,6 +170,7 @@ def get_supported_delegated_credentials_algorithms(config):
     return None
 
 
+@fix_exception
 def get_supported_versions(config):
     supported_versions = []
     extensions = config["tls"]["extensions"]
@@ -169,6 +191,7 @@ def get_supported_versions(config):
     return None
 
 
+@fix_exception
 def get_psk_key_exchange_modes(config):
     psk_key_exchange_modes = None
     extensions = config["tls"]["extensions"]
@@ -189,6 +212,7 @@ def get_signature_algorithms_cert(config):
     pass
 
 
+@fix_exception
 def get_key_share_curves(config):
     key_share_curves = []
     extensions = config["tls"]["extensions"]
@@ -214,6 +238,7 @@ def get_key_share_curves(config):
     return None
 
 
+@fix_exception
 def get_not_used_grease(config):
     not_used_grease = False
     if "TLS_GREASE" not in config["tls"]["extensions"][0]["name"]:
@@ -221,6 +246,7 @@ def get_not_used_grease(config):
     return not_used_grease
 
 
+@fix_exception
 def get_h2_settings(config):
     settings = {}
     setting_list = []
@@ -238,11 +264,13 @@ def get_h2_settings(config):
     return None
 
 
+@fix_exception
 def get_h2_settings_order(config):
     settings = get_h2_settings(config)
     return list(settings.keys())
 
 
+@fix_exception
 def get_connection_flow(config):
     connection_flow = None
     sent_frames = config["http2"]["sent_frames"]
@@ -253,6 +281,7 @@ def get_connection_flow(config):
     return connection_flow
 
 
+@fix_exception
 def get_header_priority(config):
     header_priority = None
     sent_frames = config["http2"]["sent_frames"]
@@ -269,6 +298,7 @@ def get_header_priority(config):
     return header_priority
 
 
+@fix_exception
 def get_priority_frames(config):
     priority_frames = []
     sent_frames = config["http2"]["sent_frames"]


### PR DESCRIPTION
- 新增 fix_exception 装饰器，用于捕获并处理提取配置时可能发生的异常
- 在所有提取配置的函数上添加 fix_exception 装饰器